### PR TITLE
Edit contact page

### DIFF
--- a/__tests__/ContactDetails.test.js
+++ b/__tests__/ContactDetails.test.js
@@ -17,7 +17,13 @@ describe('ContactDetails', () => {
   });
 
   it('Renders details of a contact', () => {
-    const jsontree = renderer.create(<ContactDetails navigation={navigationFake}/>).toJSON();
+    const jsontree = renderer.create(<ContactDetails navigation={navigationFake} />).toJSON();
     expect(jsontree.children[0].type).to.equal('Text');
   });
+
+  it('Renders an edit button', () => {
+    const jsontree = renderer.create(<ContactDetails navigation={navigationFake} />).toJSON();
+    expect(jsontree.children[1].type).to.equal('View');
+    expect(jsontree.children[1].props.accessibilityComponentType).to.equal('button');
+  })
 });

--- a/__tests__/EditContactForm.test.js
+++ b/__tests__/EditContactForm.test.js
@@ -22,13 +22,16 @@ describe('ContactDetails', () => {
     );
   });
 
-  it('Renders a form', () => {
+  it('Renders a form with labels', () => {
     const jsontree = renderer.create(<EditContactForm navigation={navigationFake} />).toJSON();
     expect(jsontree.children[0].type).to.equal('Text');
-    expect(jsontree.children[1].type).to.equal('TextInput');
+    expect(jsontree.children[1].type).to.equal('Text');
     expect(jsontree.children[2].type).to.equal('TextInput');
-    expect(jsontree.children[3].type).to.equal('TextInput');
-    expect(jsontree.children[4].type).to.equal('View');
-    expect(jsontree.children[4].props.accessibilityComponentType).to.equal('button');
+    expect(jsontree.children[3].type).to.equal('Text');
+    expect(jsontree.children[4].type).to.equal('TextInput');
+    expect(jsontree.children[5].type).to.equal('Text');
+    expect(jsontree.children[6].type).to.equal('TextInput');
+    expect(jsontree.children[7].type).to.equal('View');
+    expect(jsontree.children[7].props.accessibilityComponentType).to.equal('button');
   });
 });

--- a/__tests__/EditContactForm.test.js
+++ b/__tests__/EditContactForm.test.js
@@ -1,0 +1,34 @@
+import 'react-native';
+import React from 'react';
+import { expect } from 'chai';
+import EditContactForm from '../gen/components/EditContactForm.js';
+
+// Note: test renderer must be required after react-native.
+import renderer from 'react-test-renderer';
+import realm from '../gen/models/realm'
+
+describe('ContactDetails', () => {
+
+  let contactFake
+  realm.write(() => {
+    contactFake = realm.create('Contact', {name: 'JennyWem', role: 'Vaporlord', organisation: 'Vaporwave inc. ltd.', context: 'DreamWorld'});
+  });
+
+  const navigationFake = {state: {params: {contact: contactFake}}};
+
+  it('renders correctly', () => {
+    const tree = renderer.create(
+      <EditContactForm navigation={navigationFake} />
+    );
+  });
+
+  it('Renders a form', () => {
+    const jsontree = renderer.create(<EditContactForm navigation={navigationFake} />).toJSON();
+    expect(jsontree.children[0].type).to.equal('Text');
+    expect(jsontree.children[1].type).to.equal('TextInput');
+    expect(jsontree.children[2].type).to.equal('TextInput');
+    expect(jsontree.children[3].type).to.equal('TextInput');
+    expect(jsontree.children[4].type).to.equal('View');
+    expect(jsontree.children[4].props.accessibilityComponentType).to.equal('button');
+  });
+});

--- a/__tests__/Narrative.test.js
+++ b/__tests__/Narrative.test.js
@@ -11,7 +11,7 @@ describe('Narrative', () => {
 
   it('add specific info to a contact', () => {
     realm.write(() => {
-    contact = realm.create('Contact', {name: 'Jenny', role: 'Vaporlord', organisation: 'Makers Academy', context: 'Queer Code'});
+    contact = realm.create('Contact', {name: 'Wem', role: 'Vaporlord', organisation: 'Makers Academy', context: 'Queer Code'});
     });
     expect(contact.role).to.equal('Vaporlord');
     expect(contact.organisation).to.equal('Makers Academy');

--- a/gen/components/ContactDetails.js
+++ b/gen/components/ContactDetails.js
@@ -1,5 +1,5 @@
 import React from 'react';
-import { Text, View } from 'react-native';
+import { Button, Text, View } from 'react-native';
 
 import { hook } from 'cavy';
 
@@ -8,13 +8,33 @@ class ContactDetails extends React.Component {
     super(props)
     this.state = {contact: this.props.navigation.state.params.contact}
   }
+
+  navigateToEdit() {
+    this.props.navigation.navigate('EditContact', {contact: this.state.contact})
+  }
+
+  navigateToHome() {
+    this.props.navigation.navigate('Contacts')
+  }
+
   render() {
     return (
       <View ref={this.props.generateTestHook(`ContactDetails.${this.state.contact.name}`)}>
         <Text>
           { this.state.contact.name }
           { this.state.contact.tags[0].name }
+          { this.state.contact.role }
         </Text>
+        <Button
+          ref={this.props.generateTestHook('ContactDetails.EditButton')}
+          title='Edit contact'
+          onPress={this.navigateToEdit.bind(this)}
+        />
+        <Button
+          ref={this.props.generateTestHook('ContactDetails.HomeButton')}
+          title='Home'
+          onPress={this.navigateToHome.bind(this)}
+        />
       </View>
     )
   };

--- a/gen/components/ContactDetails.js
+++ b/gen/components/ContactDetails.js
@@ -23,7 +23,6 @@ class ContactDetails extends React.Component {
         <Text>
           { this.state.contact.name }
           { this.state.contact.tags[0].name }
-          { this.state.contact.role }
         </Text>
         <Button
           ref={this.props.generateTestHook('ContactDetails.EditButton')}

--- a/gen/components/EditContactForm.js
+++ b/gen/components/EditContactForm.js
@@ -1,0 +1,68 @@
+import React from 'react';
+import {
+  Alert,
+  Button,
+  Text,
+  TextInput,
+  View
+} from 'react-native';
+import { hook } from 'cavy';
+import realm from '../models/realm'
+
+class EditContactForm extends React.Component {
+  constructor(props) {
+    super(props)
+    const contact = this.props.navigation.state.params.contact
+    this.state = { contact: contact,
+                   role: contact.role,
+                   organisation: contact.organisation,
+                   context: contact.context }
+    this.updateContact = this.updateContact.bind(this);
+  }
+
+  updateContact() {
+    realm.write(() => {
+      const contact = realm.objects('Contact').filtered(`name = "${this.state.contact.name}"`)
+      const updatedContact = realm.create('Contact', {
+                                              name: this.state.contact.name,
+                                              role: this.state.role,
+                                              organisation: this.state.organisation,
+                                              context: this.state.context
+                                            },
+                                          true)
+    });
+    Alert.alert(`Updated details for ${this.state.contact.name}`)
+  }
+
+  render() {
+    return (
+      <View>
+        <Text>
+          Update {this.state.contact.name}'s details
+        </Text>
+        <TextInput
+          onChangeText={(role) => this.setState({role})}
+          ref={this.props.generateTestHook('EditContactForm.RoleInput')}
+          placeholder={this.state.contact.role}
+        />
+        <TextInput
+          onChangeText={(organisation) => this.setState({organisation})}
+          ref={this.props.generateTestHook('EditContactForm.OrganisationInput')}
+          placeholder={this.state.contact.organisation}
+        />
+        <TextInput
+          onChangeText={(context) => this.setState({context})}
+          ref={this.props.generateTestHook('EditContactForm.ContextInput')}
+          placeholder={this.state.contact.context}
+        />
+        <Button
+          onPress={this.updateContact}
+          ref={this.props.generateTestHook('EditContactForm.Button')}
+          title='Update contact details'
+        />
+      </View>
+    )
+  }
+}
+
+export default hook(EditContactForm)

--- a/gen/components/EditContactForm.js
+++ b/gen/components/EditContactForm.js
@@ -43,17 +43,17 @@ class EditContactForm extends React.Component {
         <TextInput
           onChangeText={(role) => this.setState({role})}
           ref={this.props.generateTestHook('EditContactForm.RoleInput')}
-          placeholder={this.state.contact.role}
+          value={this.state.role}
         />
         <TextInput
           onChangeText={(organisation) => this.setState({organisation})}
           ref={this.props.generateTestHook('EditContactForm.OrganisationInput')}
-          placeholder={this.state.contact.organisation}
+          value={this.state.organisation}
         />
         <TextInput
           onChangeText={(context) => this.setState({context})}
           ref={this.props.generateTestHook('EditContactForm.ContextInput')}
-          placeholder={this.state.contact.context}
+          value={this.state.context}
         />
         <Button
           onPress={this.updateContact}

--- a/gen/components/EditContactForm.js
+++ b/gen/components/EditContactForm.js
@@ -40,16 +40,25 @@ class EditContactForm extends React.Component {
         <Text>
           Update {this.state.contact.name}'s details
         </Text>
+        <Text>
+          Role:
+        </Text>
         <TextInput
           onChangeText={(role) => this.setState({role})}
           ref={this.props.generateTestHook('EditContactForm.RoleInput')}
           value={this.state.role}
         />
+        <Text>
+          Organisation:
+        </Text>
         <TextInput
           onChangeText={(organisation) => this.setState({organisation})}
           ref={this.props.generateTestHook('EditContactForm.OrganisationInput')}
           value={this.state.organisation}
         />
+        <Text>
+          Where you met:
+        </Text>
         <TextInput
           onChangeText={(context) => this.setState({context})}
           ref={this.props.generateTestHook('EditContactForm.ContextInput')}

--- a/gen/models/realm.js
+++ b/gen/models/realm.js
@@ -2,24 +2,27 @@ import Realm from 'realm';
 
 class Contact {}
 Contact.schema = {
-    name: 'Contact',
-    properties: {
+  name: 'Contact',
+  primaryKey: 'name',
+  properties: {
     name: 'string',
     role: {type: 'string', optional: true},
     organisation: {type: 'string', optional: true},
     context: {type: 'string', optional: true},
     tags: {
-      type: 'list', objectType: 'Tag'},
+      type: 'list', objectType: 'Tag'
     },
+  },
 };
 
 class Tag {}
 Tag.schema = {
-  name: 'Tag',
-  properties: {
-  name: 'string',
-  contacts: {
-    type: 'list', objectType: 'Contact'},
+    name: 'Tag',
+    properties: {
+    name: 'string',
+    contacts: {
+      type: 'list', objectType: 'Contact'
+    },
   },
 };
 

--- a/gen/navigation/router.js
+++ b/gen/navigation/router.js
@@ -3,6 +3,7 @@ import { StackNavigator } from 'react-navigation';
 
 import RememberAllApp from '../components/RememberAllApp';
 import ContactDetails from '../components/ContactDetails';
+import EditContactForm from '../components/EditContactForm';
 
 export const Root = StackNavigator({
   Contacts: {
@@ -10,5 +11,8 @@ export const Root = StackNavigator({
   },
   Details: {
     screen: ContactDetails,
+  },
+  EditContact: {
+    screen: EditContactForm,
   },
 })

--- a/index.android.js
+++ b/index.android.js
@@ -15,13 +15,14 @@ import { Root } from './gen/navigation/router'
 import AddContactSpec from './specs/AddContactSpec';
 import SearchBarSpec from './specs/SearchBarSpec';
 import ContactDetailsSpec from './specs/ContactDetailsSpec';
+import EditContactSpec from './specs/EditContactSpec';
 const testHookStore = new TestHookStore();
 
 
 export default class RememberAll extends Component {
   render() {
     return (
-      <Tester specs={[AddContactSpec, SearchBarSpec, ContactDetailsSpec]} store={testHookStore} waitTime={2000} startDelay={3000}>
+      <Tester specs={[AddContactSpec, ContactDetailsSpec, EditContactSpec, SearchBarSpec]} store={testHookStore} waitTime={1000} startDelay={1000}>
         <Root />
       </Tester>
     );

--- a/index.ios.js
+++ b/index.ios.js
@@ -15,13 +15,14 @@ import { Root } from './gen/navigation/router'
 import AddContactSpec from './specs/AddContactSpec';
 import SearchBarSpec from './specs/SearchBarSpec';
 import ContactDetailsSpec from './specs/ContactDetailsSpec';
+import EditContactSpec from './specs/EditContactSpec';
 const testHookStore = new TestHookStore();
 
 
 export default class RememberAll extends Component {
   render() {
     return (
-      <Tester specs={[AddContactSpec, SearchBarSpec, ContactDetailsSpec]} store={testHookStore} waitTime={2000} startDelay={3000}>
+      <Tester specs={[AddContactSpec, ContactDetailsSpec, EditContactSpec, SearchBarSpec]} store={testHookStore} waitTime={1000} startDelay={1000}>
         <Root />
       </Tester>
     );

--- a/specs/AddContactSpec.js
+++ b/specs/AddContactSpec.js
@@ -11,10 +11,10 @@ export default function(spec) {
   });
 
   spec.it('shows contact tags', async function() {
-    await spec.fillIn('NewContactForm.NameInput', 'Sally');
+    await spec.fillIn('NewContactForm.NameInput', 'Sarah');
     await spec.fillIn('NewContactForm.TagsInput', 'Cool');
     await spec.press('NewContactForm.Button');
     await spec.pause(1000);
-    await spec.exists('Contact.Sally');
+    await spec.exists('Contact.Sarah');
   });
 }

--- a/specs/EditContactSpec.js
+++ b/specs/EditContactSpec.js
@@ -1,0 +1,17 @@
+export default function(spec) {
+
+  spec.describe('Editing a contact', function() {
+
+    spec.it('adds information to the contact', async function() {
+      await spec.fillIn('NewContactForm.NameInput', 'Oberyn');
+      await spec.press('NewContactForm.Button');
+      await spec.press('Contact.Oberyn');
+      await spec.press('ContactDetails.EditButton');
+      await spec.fillIn('EditContactForm.OrganisationInput', 'House Martell');
+      await spec.press('EditContactForm.Button');
+      await spec.press('ContactDetails.HomeButton');
+      await spec.fillIn('SearchBar.TextInput', 'Martell');
+      await spec.exists('Contact.Oberyn');
+    });
+  });
+}


### PR DESCRIPTION
We now have a form for editing a contact's role/organisation/context.
A few awkward things have had to be changed in order for this to work, bless React Native and Realm's cotton socks:

- MOST IMPORTANTLY: We now have to wipe the database before running any test suites.

- Contacts now have 'name' as their primary key.  This means we can't ever change the name, but Realm won't let us do an update without a primary key (and since there's no auto-incrementing id this was the most convenient way for now).
- There is a 'Home' button on the Contact Details page, as well as the back button; this is so that Cavy can navigate back to the ContactsList screen (we can't put a ref on the back button).
- Some names in the Jest tests have been changed so that there are no duplicates.